### PR TITLE
fix XSS in headers in history

### DIFF
--- a/src/legacy/ui/markdown.js
+++ b/src/legacy/ui/markdown.js
@@ -30,7 +30,7 @@ renderer.link = function (href, title, text) {
 }
 renderer.heading = function (text, level, raw) {
   // this is a hack, we should replace the markdown parser
-  return (new Array(level+1)).join("#") + raw
+  return (new Array(level+1)).join("#") + text
 }
 renderer.hr = function () {
   return "--"


### PR DESCRIPTION
https://github.com/ubergrape/chatgrape/issues/3724

very simple fix for the XSS in the (still used) legacy history/markdown
