### PR TITLE
Chore/improve proxy

### DIFF
--- a/proxy.js
+++ b/proxy.js
@@ -25,7 +25,7 @@ const argv = parseArgs(process.argv.slice(2))
 const listenOnPort = argv.port || '3128'
 const devHost = argv.devHost || 'localhost'
 const devPort = argv.devPort || '8080'
-const devPath = argv.devPath || '/dist/app'
+const devPath = argv.devPath || '/static/app'
 const helpRequested = argv.h || argv.help
 
 const proxy = Proxy()

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -106,7 +106,7 @@ module.exports = exports = {
 }
 
 if (isDevServer) {
-  exports.output.publicPath = '/dist/app/'
+  exports.output.publicPath = '/static/app/'
   // TODO: hotloading.
 }
 


### PR DESCRIPTION
This PR does the following:
- Disables SSLv2 and v3, also because Safari won't connect when supporting v3 for some reasons on some websites including chatgrape.
- Matches publicPath with `staging` and `dev` to have the same config environment

Notes:
- If you still use `Requestly` you need to redirect to `/static/app` instead of `/dist/app` after this patch.