### PR TITLE
Fix for embedded chat, crashed because of empty route

### DIFF
--- a/src/app/AppEmbedded.js
+++ b/src/app/AppEmbedded.js
@@ -29,7 +29,7 @@ export default class AppEmbedded extends PureComponent {
   render() {
     return (
       <AppProvider>
-        {() =>
+        {() => (
           <FakeRouter>
             <AppContainer>
               <AppLayout
@@ -42,7 +42,7 @@ export default class AppEmbedded extends PureComponent {
               />
             </AppContainer>
           </FakeRouter>
-        }
+        )}
       </AppProvider>
     )
   }

--- a/src/app/AppFull.js
+++ b/src/app/AppFull.js
@@ -68,7 +68,7 @@ export default class App extends PureComponent {
   render() {
     return (
       <AppProvider>
-        {props =>
+        {props => (
           <Router {...props}>
             <AppLayout
               Aside={Aside}
@@ -81,7 +81,7 @@ export default class App extends PureComponent {
               Footer={FooterProvider}
             />
           </Router>
-        }
+        )}
       </AppProvider>
     )
   }

--- a/src/containers/router/FakeRouter.js
+++ b/src/containers/router/FakeRouter.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types'
 import React, {PureComponent} from 'react'
-import createHistory from 'history/createBrowserHistory'
+import history from '../../app/history'
 
 class FakeRouter extends PureComponent {
   static childContextTypes = {
@@ -8,7 +8,6 @@ class FakeRouter extends PureComponent {
   };
 
   getChildContext() {
-    const history = createHistory()
     return {
       router: {
         history: {


### PR DESCRIPTION
Embedded chat now crashing, because of using <Link> component outside of Router.