### PR TITLE
Changed control icons size and padding

### DIFF
--- a/src/components/footer/Controls.js
+++ b/src/components/footer/Controls.js
@@ -5,6 +5,7 @@ import Dropzone from 'react-dropzone'
 import {bigger} from 'grape-theme/dist/fonts'
 import IconButton from 'grape-web/lib/components/icon-button'
 import Icon from 'grape-web/lib/svg-icons/Icon'
+import {iconSize, buttonSize} from './constants'
 
 import {maxSize as maxFileSize} from '../file-upload'
 import {Beacon} from '../intro'
@@ -52,17 +53,16 @@ const AttachmentButton = (props) => {
     flexShrink: 0
   },
   button: {
-    padding: 5,
-    width: 29,
-    height: 29,
+    width: buttonSize,
+    height: buttonSize,
     '&:hover': {
       isolate: false,
       color: palette.secondary.A200
     }
   },
   contolIcon: {
-    width: 19,
-    height: 19
+    width: iconSize,
+    height: iconSize
   },
   dropzone: {}
 }))

--- a/src/components/footer/constants.js
+++ b/src/components/footer/constants.js
@@ -1,3 +1,5 @@
-import {spacer} from 'grape-theme/dist/sizes'
+import {spacer, icon} from 'grape-theme/dist/sizes'
 
 export const controlSpacing = spacer.s / 2
+export const iconSize = icon.m
+export const buttonSize = icon.xl


### PR DESCRIPTION
That's a reset of default styles of dropzone: https://github.com/ubergrape/grape-web-client/compare/bug/change-control-icon-size?expand=1#diff-9286ca7d6b36c96097499ff7fe3dde4eR67