### PR TITLE
reset history if current channel is deleted

### DIFF
--- a/src/actions/pubSubHandlers.js
+++ b/src/actions/pubSubHandlers.js
@@ -49,7 +49,10 @@ const addNewMessage = message => (dispatch, getState) => {
 
   dispatch({
     type: types.ADD_NEW_MESSAGE,
-    payload: nMessage,
+    payload: {
+      message: nMessage,
+      currentUserId: user.id,
+    },
   })
 }
 
@@ -244,7 +247,6 @@ export function handleRemoveRoom({ channel: id }) {
       payload: id,
     })
     if (id === currentId) dispatch(goTo('/chat'))
-    dispatch(handleCurrentUserLeftChannel())
   }
 }
 

--- a/src/reducers/__tests__/__snapshots__/history.js.snap
+++ b/src/reducers/__tests__/__snapshots__/history.js.snap
@@ -21,9 +21,6 @@ Object {
   "scrollTo": null,
   "scrollToAlignment": null,
   "showNoContent": false,
-  "user": Object {
-    "id": "userId1",
-  },
 }
 `;
 
@@ -57,9 +54,6 @@ Object {
   "scrollTo": null,
   "scrollToAlignment": null,
   "showNoContent": false,
-  "user": Object {
-    "id": "userId1",
-  },
 }
 `;
 
@@ -81,9 +75,6 @@ Object {
   "scrollTo": null,
   "scrollToAlignment": null,
   "showNoContent": false,
-  "user": Object {
-    "id": "userId1",
-  },
 }
 `;
 
@@ -113,9 +104,6 @@ Object {
   "scrollTo": "msgId1",
   "scrollToAlignment": null,
   "showNoContent": false,
-  "user": Object {
-    "id": "userId1",
-  },
 }
 `;
 
@@ -145,9 +133,6 @@ Object {
   "scrollTo": null,
   "scrollToAlignment": null,
   "showNoContent": false,
-  "user": Object {
-    "id": "userId1",
-  },
 }
 `;
 

--- a/src/reducers/__tests__/history.js
+++ b/src/reducers/__tests__/history.js
@@ -24,7 +24,10 @@ describe('history reducer', () => {
       expect(
         history(
           { channel: { id: 'aaa' } },
-          { type: ADD_NEW_MESSAGE, payload: { channelId: 'bbb', id: 'bbb' } },
+          {
+            type: ADD_NEW_MESSAGE,
+            payload: { message: { channelId: 'bbb', id: 'bbb' } },
+          },
         ),
       ).toMatchSnapshot()
     })
@@ -33,16 +36,18 @@ describe('history reducer', () => {
       expect(
         history(
           {
-            user: { id: 'userId1' },
             channel: { id: 'channelId1' },
             messages: [],
           },
           {
             type: ADD_NEW_MESSAGE,
             payload: {
-              id: 'msgId1',
-              author: { id: 'userId1' },
-              channelId: 'channelId1',
+              message: {
+                id: 'msgId1',
+                author: { id: 'userId1' },
+                channelId: 'channelId1',
+              },
+              currentUserId: 'userId1',
             },
           },
         ),
@@ -53,16 +58,18 @@ describe('history reducer', () => {
       expect(
         history(
           {
-            user: { id: 'userId1' },
             channel: { id: 'channelId1' },
             messages: [],
           },
           {
             type: ADD_NEW_MESSAGE,
             payload: {
-              id: 'msgId1',
-              author: { id: 'userId2' },
-              channelId: 'channelId1',
+              message: {
+                id: 'msgId1',
+                author: { id: 'userId2' },
+                channelId: 'channelId1',
+              },
+              currentUserId: 'userId1',
             },
           },
         ),
@@ -73,7 +80,6 @@ describe('history reducer', () => {
       expect(
         history(
           {
-            user: { id: 'userId1' },
             messages: [
               { id: '234' },
               { clientsideId: 'abc' },
@@ -84,10 +90,13 @@ describe('history reducer', () => {
           {
             type: ADD_NEW_MESSAGE,
             payload: {
-              id: '123',
-              author: { id: 'userId2' },
-              clientsideId: 'abc',
-              channelId: 'channelId1',
+              message: {
+                id: '123',
+                author: { id: 'userId2' },
+                clientsideId: 'abc',
+                channelId: 'channelId1',
+              },
+              currentUserId: 'userId1',
             },
           },
         ),
@@ -98,7 +107,6 @@ describe('history reducer', () => {
       expect(
         history(
           {
-            user: { id: 'userId1' },
             messages: [
               { id: '234' },
               { id: '345', clientsideId: 'abc' },
@@ -109,10 +117,13 @@ describe('history reducer', () => {
           {
             type: ADD_NEW_MESSAGE,
             payload: {
-              id: '123',
-              author: { id: 'userId2' },
-              clientsideId: 'xyz',
-              channelId: 'channelId1',
+              message: {
+                id: '123',
+                author: { id: 'userId2' },
+                clientsideId: 'xyz',
+                channelId: 'channelId1',
+              },
+              currentUserId: 'userId1',
             },
           },
         ),
@@ -123,16 +134,18 @@ describe('history reducer', () => {
       expect(
         history(
           {
-            user: { id: 'userId1' },
             messages: [{ clientsideId: 'abc' }],
             channel: { id: 'channelId1' },
           },
           {
             type: ADD_NEW_MESSAGE,
             payload: {
-              id: '123',
-              channelId: 'channelId1',
-              author: { id: 'userId2' },
+              message: {
+                id: '123',
+                channelId: 'channelId1',
+                author: { id: 'userId2' },
+              },
+              currentUserId: 'userId1',
             },
           },
         ),

--- a/src/reducers/history.js
+++ b/src/reducers/history.js
@@ -49,8 +49,6 @@ function markLastMessageAsRead(messages, senderId) {
 export default function reduce(state = initialState, action) {
   const { payload } = action
   switch (action.type) {
-    case types.SET_USER:
-      return { ...state, user: payload }
     case types.SET_CHANNEL:
       return {
         ...state,
@@ -62,8 +60,6 @@ export default function reduce(state = initialState, action) {
         loadedNewerMessage: false,
         backendHasNewerMessages: true,
       }
-    case types.SET_USERS:
-      return { ...state, users: payload }
     case types.HANDLE_INITIAL_HISTORY: {
       const {
         messages,
@@ -129,6 +125,11 @@ export default function reduce(state = initialState, action) {
     case types.SET_INITIAL_DATA_LOADING:
       if (!payload) return state
       return { ...initialState }
+    case types.REMOVE_ROOM:
+      if (state.channel && payload === state.channel.id) {
+        return { ...initialState }
+      }
+      return state
     case types.CLEAR_HISTORY:
       return {
         ...state,
@@ -197,10 +198,11 @@ export default function reduce(state = initialState, action) {
       }
       // Do not append a message if the history is not up to date
       if (state.backendHasNewerMessages) return state
-      const scrollTo = payload.author.id === state.user.id ? payload.id : null
       return {
         ...state,
-        scrollTo,
+        // REQUEST_POST_MESSAGE is always triggered by the current user and thats
+        // why we can scroll to the message (bottom of the chat) right away
+        scrollTo: payload.id,
         scrollToAlignment: null,
         messages: uniqBy(
           [...state.messages, { ...payload, state: 'pending' }],
@@ -211,42 +213,45 @@ export default function reduce(state = initialState, action) {
       }
     }
     case types.ADD_NEW_MESSAGE: {
-      if (payload.channelId !== state.channel.id) return state
+      const newMessage = payload.message
+      if (newMessage.channelId !== state.channel.id) return state
       // Do not append a message if the history is not up to date
       if (state.backendHasNewerMessages) return state
 
-      const { messages } = state
-      const newMessages = [...messages]
+      const messages = [...state.messages]
       // this case occures when the message was added to the history
       // optimistically without waiting for a server response
       if (
-        !isNil(payload.clientsideId) &&
-        some(newMessages, msg => msg.clientsideId === payload.clientsideId)
+        !isNil(newMessage.clientsideId) &&
+        some(messages, msg => msg.clientsideId === newMessage.clientsideId)
       ) {
-        const index = findIndex(newMessages, {
-          clientsideId: payload.clientsideId,
+        const index = findIndex(messages, {
+          clientsideId: newMessage.clientsideId,
         })
-        const currMessage = newMessages[index]
+        const currMessage = messages[index]
         // state is changed to sent since after receiveing the message from
         // the server we can be sure it has been sent
-        const message = { ...currMessage, ...payload, state: 'sent' }
-        newMessages.splice(index, 1, message)
+        const message = { ...currMessage, ...newMessage, state: 'sent' }
+        messages.splice(index, 1, message)
         return {
           ...state,
           scrollTo: null,
           scrollToAlignment: null,
-          messages: uniqBy([...newMessages], 'id'),
+          messages: uniqBy([...messages], 'id'),
           showNoContent: false,
           loadedNewerMessage: false,
         }
       }
 
-      const scrollTo = payload.author.id === state.user.id ? payload.id : null
+      // If the message was added by the current user we are sure she/he has seen it and
+      // we scroll to the new message (bottom of the chat)
+      const scrollTo =
+        newMessage.author.id === payload.currentUserId ? newMessage.id : null
       return {
         ...state,
         scrollTo,
         scrollToAlignment: null,
-        messages: uniqBy([...newMessages, payload], 'id'),
+        messages: uniqBy([...messages, newMessage], 'id'),
         showNoContent: false,
         loadedNewerMessage: false,
       }

--- a/src/selectors/index.js
+++ b/src/selectors/index.js
@@ -564,18 +564,24 @@ export const historyComponentSelector = createSelector(
     orgSelector,
     initialDataLoadingSelector,
     joinedChannelsSelector,
+    userSelector,
+    usersSelector,
   ],
   (
     history,
     { customEmojis, permissions },
     isLoadingInitialData,
     isMemberOfAnyRooms,
+    user,
+    users,
   ) => ({
     ...omit(history, 'olderMessagesRequest', 'newerMessagesRequest'),
     customEmojis,
     permissions,
     isLoadingInitialData,
     isMemberOfAnyRooms,
+    user,
+    users,
   }),
 )
 


### PR DESCRIPTION
When reseting the history to the initialState in REMOVE_ROOM I noticed the history state `user` and `users` were missing. This lead me to refactor the code and remove both from history since they shouldn't be duplicated in there.